### PR TITLE
make Lombok dependency 'provided'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,8 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.6</version>
+            <version>1.16.8</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Logging -->


### PR DESCRIPTION
Hi,

according to Lombok documentation, the dependency need's just to be declared as 'provided'.
So I changed this and updated to the latest version.

https://projectlombok.org/mavenrepo/index.html

Feedback is always welcome ;-)
